### PR TITLE
Use correct separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -17,14 +17,14 @@ setUuid	KEYWORD2
 setSourceName	KEYWORD2
 setUniverse	KEYWORD2
 setChannel	KEYWORD2
-sendPacket  KEYWORD2
-setSequenceNumber  KEYWORD2
-getSequenceNumber  KEYWORD2
-setSyncAddress  KEYWORD2
-setOptions  KEYWORD2
-readData  KEYWORD2
-packetSize  KEYWORD2
-sendPacket  KEYWORD2
+sendPacket	KEYWORD2
+setSequenceNumber	KEYWORD2
+getSequenceNumber	KEYWORD2
+setSyncAddress	KEYWORD2
+setOptions	KEYWORD2
+readData	KEYWORD2
+packetSize	KEYWORD2
+sendPacket	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)


### PR DESCRIPTION
The Arduino IDE currently requires the use of a single true tab separator between the name and identifier. Without this tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords